### PR TITLE
Fix automatic IP address resolving

### DIFF
--- a/MobileManager.Configuration/ManagerConfiguration.cs
+++ b/MobileManager.Configuration/ManagerConfiguration.cs
@@ -105,7 +105,13 @@ namespace MobileManager.Configuration
 
             foreach (var currentIpAddress in Dns.GetHostAddresses(Dns.GetHostName()))
             {
+
                 if (currentIpAddress.ToString().StartsWith("169"))
+                {
+                    continue;
+                }
+
+                if (currentIpAddress.ToString().StartsWith("127"))
                 {
                     continue;
                 }

--- a/MobileManager.Configuration/ManagerConfiguration.cs
+++ b/MobileManager.Configuration/ManagerConfiguration.cs
@@ -105,12 +105,13 @@ namespace MobileManager.Configuration
 
             foreach (var currentIpAddress in Dns.GetHostAddresses(Dns.GetHostName()))
             {
-
+                // not set IP address by DHCP (probably no connection on interface)
                 if (currentIpAddress.ToString().StartsWith("169"))
                 {
                     continue;
                 }
 
+                // loopback for localhost 
                 if (currentIpAddress.ToString().StartsWith("127"))
                 {
                     continue;


### PR DESCRIPTION
This fix is necessary because of update on MacOs X Catalina - there is strange behavior during automatic resolving of adapter IP address (in case that ListeningIpAddress is not set in managerconfig.json file). 

Order of adapters in list are changing and many times were chosen loop-back adapter 127.0.0.1, but this adapter is every time already in use, because MM is listening on 127.0.0.1 by default. In that case starting of MM failed with critical error. 

Tested on Win10 and MacOS 10.15.