### PR TITLE
Bugfix/android screenshots

### DIFF
--- a/MobileManager/Services/ScreenshotService.cs
+++ b/MobileManager/Services/ScreenshotService.cs
@@ -85,13 +85,16 @@ namespace MobileManager.Services
                 Directory.CreateDirectory(screenshotFolder);
                 var screenshotFilePath = Path.Combine(screenshotFolder, $"{device.Id}.png");
 
-                // adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > screen.png
-                var screenshotRet = _externalProcesses.RunShellProcess("adb",
-                    $" --args -s {device.Id} exec-out 'screencap -p' > {screenshotFilePath}; exit 0", 10000);
-                _logger.Info(_externalProcesses.ToString());
-                _logger.Debug(screenshotRet);
+                var screenshotRet = _externalProcesses.RunProcessAndReadOutput("adb",
+                    $"-s {device.Id} shell 'screencap -p' /sdcard/{device.Id}.png", 10000);
 
-                if (screenshotRet.Contains("error:"))
+                var screenshotPull = _externalProcesses.RunProcessAndReadOutput("adb",
+                    $"-s {device.Id} pull /sdcard/{device.Id}.png {screenshotFilePath}", 10000);
+
+                _logger.Debug(screenshotRet);
+                _logger.Debug(screenshotPull);
+
+                if (screenshotRet.Contains("error:") || screenshotPull.Contains("error:"))
                 {
                     return GetDefaultMobileImage();
                 }

--- a/MobileManager/Services/ScreenshotService.cs
+++ b/MobileManager/Services/ScreenshotService.cs
@@ -86,7 +86,7 @@ namespace MobileManager.Services
                 var screenshotFilePath = Path.Combine(screenshotFolder, $"{device.Id}.png");
 
                 var screenshotRet = _externalProcesses.RunProcessAndReadOutput("adb",
-                    $"-s {device.Id} shell 'screencap -p' /sdcard/{device.Id}.png", 10000);
+                    $"-s {device.Id} shell screencap -p /sdcard/{device.Id}.png", 10000);
 
                 var screenshotPull = _externalProcesses.RunProcessAndReadOutput("adb",
                     $"-s {device.Id} pull /sdcard/{device.Id}.png {screenshotFilePath}", 10000);

--- a/MobileManager/Services/ScreenshotService.cs
+++ b/MobileManager/Services/ScreenshotService.cs
@@ -87,7 +87,8 @@ namespace MobileManager.Services
 
                 // adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > screen.png
                 var screenshotRet = _externalProcesses.RunShellProcess("adb",
-                    $" -s {device.Id} exec-out 'screencap -p' > {screenshotFilePath}; exit 0", 10000);
+                    $" --args -s {device.Id} exec-out 'screencap -p' > {screenshotFilePath}; exit 0", 10000);
+                _logger.Info(_externalProcesses.ToString());
                 _logger.Debug(screenshotRet);
 
                 if (screenshotRet.Contains("error:"))


### PR DESCRIPTION
Rework of taking screenshot on Android devices. It wasn't working after updating on MacOS Catalina. In new MacOs Catalina was change default shell from Bash to Zsh and that probably caused problem with starting ADB trough Process.Start with UseShellExecute. To avoid similar complications in future I have reworked this on standard process handling without shell background and do it more safe and proper way - take&pull. 
https://github.com/dixons/mobile-manager/issues/33